### PR TITLE
if url is a data URI scheme, do not guess type based on extension.

### DIFF
--- a/kmz/geoxml3.js
+++ b/kmz/geoxml3.js
@@ -172,7 +172,16 @@ geoXML3.parser = function (options) {
     resFunc = resFunc || function (responseXML) { render(responseXML, doc); };
 
     if (typeof ZipFile === 'function' && typeof JSIO === 'object' && typeof JSIO.guessFileType === 'function') {  // KMZ support requires these modules loaded
-      contentType = JSIO.guessFileType(doc.baseUrl);
+      // if url is a data URI scheme, do not guess type based on extension.
+      if (/^data:[^,]*(kmz)/.test(doc.baseUrl)) {
+         contentType = JSIO.FileType.Binary;
+      } else if (/^data:[^,]*(kml|xml)/.test(doc.baseUrl)) {
+         contentType = JSIO.FileType.XML;
+      } else if (/^data:/.test(doc.baseUrl)) {
+         contentType = JSIO.FileType.Unknown;
+      } else {
+         contentType = JSIO.guessFileType(doc.baseUrl);
+      }
       if (contentType == JSIO.FileType.Binary || contentType == JSIO.FileType.Unknown) {
          doc.isCompressed = true;
          doc.baseDir = doc.baseUrl + '/';


### PR DESCRIPTION
To use geoxml3 with a local file, you can read it with readAsDataURL. In this case the end of the file/URL makes no sense as an extension.
In case of data URI scheme, look on this data to find out if it is a KML or KMZ .