### PR TITLE
fix zoom issue

### DIFF
--- a/ProjectedOverlay.js
+++ b/ProjectedOverlay.js
@@ -93,15 +93,6 @@ ProjectedOverlay.prototype.draw = function(firstTime)
  this.div_.style.left = Math.min(c2.x, c1.x) + "px";
  this.div_.style.top = Math.min(c2.y, c1.y) + "px";
 
- // Do the rest only if the zoom has changed...
- 
- if ( this.lastZoom_ == this.map_.getZoom() )
- {
-  return ;
- }
-
- this.lastZoom_ = this.map_.getZoom() ;
-
  var url = this.url_ ;
 
  if ( this.addZ_ )
@@ -110,6 +101,15 @@ ProjectedOverlay.prototype.draw = function(firstTime)
  }
 
  this.div_.innerHTML = '<img src="' + url + '"  width=' + this.div_.style.width + ' height=' + this.div_.style.height + ' >' ;
+	
+ // Do the rest only if the zoom has changed...
+ 
+ if ( this.lastZoom_ == this.map_.getZoom() )
+ {
+  return ;
+ }
+
+ this.lastZoom_ = this.map_.getZoom() ;
 }
 
 ProjectedOverlay.prototype.setOpacity=function(opacity)


### PR DESCRIPTION
zoom manipulation should be done after all action has been done in draw method. or there will be overlay issue when zooming in and out. 
Already tested in http://www.geocodezip.com/geoxml3_test/v3_geoxml3_kmztest_linktoB.html?filename=http://www.geocodezip.com/geoxml3_test/kml/zk01w7hhv4_o.kml
originally when you zoom in and out the image will not fit into the map.
this issue happens recently and i think it is caused by newly updated google getzoom api.