### PR TITLE
improving performance of big polygons parsing

### DIFF
--- a/polys/geoxml3.js
+++ b/polys/geoxml3.js
@@ -422,7 +422,8 @@ var coordListA = [];
         var GeometryNodes = node.getElementsByTagName('coordinates');
         var Geometry = null;
 	if (!!GeometryNodes && (GeometryNodes.length > 0)) {
-          for (var gn=0;gn<GeometryNodes.length;gn++) {
+          var shouldRun = true;
+          for (var gn=0;gn<GeometryNodes.length && shouldRun;gn++) {
              if (!GeometryNodes[gn].parentNode ||
                  !GeometryNodes[gn].parentNode.nodeName) {
 
@@ -457,6 +458,7 @@ var coordListA = [];
                placemark.Polygon[pg].innerBoundaryIs = processPlacemarkCoords(polygonNodes[pg], "innerBoundaryIs");
             }
             coordList = placemark.Polygon[0].outerBoundaryIs;
+            shouldRun = false;	
             break;
 
           case "LineString":


### PR DESCRIPTION
This is a functional fix for polygon parsing; the bug that is addressed by the fix is that polygons with > 1000 lines take a long time to parse.
This is because the loop goes through the polygon parsing for each coordinate entry: this is unnecessary and degrades performance a lot: more coordinates results in more unnecessary loops. 
The fix cuts the loop for polygons after the first parsing.
Of course, this is a sort of a hack ... the correct way to fix this would be to follow the top-down structure of the kml instead of looping directly over all coordinates, just to go back to the parent, parse the parent and then do it all over again ...